### PR TITLE
bugfix：当请求参数为 type = null 时，参数校验通过

### DIFF
--- a/hai-music-server/src/main/java/com/yanghi/haimusic/bean/Comments.java
+++ b/hai-music-server/src/main/java/com/yanghi/haimusic/bean/Comments.java
@@ -83,5 +83,5 @@ public class Comments implements Serializable {
     //评论的类型 1 歌曲 2 歌单 3 MV
 
     @AllowedValuesConstraint
-    private int type;
+    private Integer type;
 }

--- a/hai-music-server/src/main/java/com/yanghi/haimusic/controller/AdminController.java
+++ b/hai-music-server/src/main/java/com/yanghi/haimusic/controller/AdminController.java
@@ -3,10 +3,12 @@ package com.yanghi.haimusic.controller;
 import com.yanghi.haimusic.bean.Admin;
 import com.yanghi.haimusic.service.AdminService;
 import com.yanghi.haimusic.utils.Result;
+import com.yanghi.haimusic.validators.AllowedValuesConstraint;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 
 import javax.annotation.Resource;
+import javax.validation.Valid;
 import javax.validation.constraints.NotNull;
 import java.util.List;
 
@@ -26,7 +28,7 @@ public class AdminController {
      * 返回指定管理员信息
      */
     @GetMapping("/{id}")
-    public Result<Admin> returnAdminInfoById(@PathVariable("id") @NotNull(message = "用户名不能为空") Integer id){
+    public Result<Admin> returnAdminInfoById(@PathVariable("id") @NotNull(message = "用户ID不为空") Integer id){
         return adminService.getAdminById(id);
     }
 
@@ -37,5 +39,10 @@ public class AdminController {
     @GetMapping("/")
     public Result<List<Admin>> returnAllAdminInfo(){
         return adminService.getAllAdmin();
+    }
+
+    @GetMapping("/test/{test}")
+    public Result test( @AllowedValuesConstraint @PathVariable("test") Integer test){
+        return Result.ok(test);
     }
 }

--- a/hai-music-server/src/main/java/com/yanghi/haimusic/controller/CommentController.java
+++ b/hai-music-server/src/main/java/com/yanghi/haimusic/controller/CommentController.java
@@ -29,7 +29,9 @@ public class CommentController {
      * @return
      */
     @PostMapping("/user")
-    public Result saveCommentsByUser(@Validated Comments comments){
+    public Result saveCommentsByUser(@Valid Comments comments){
         return commentsService.saveUserOneComments(comments);
     }
+
+
 }

--- a/hai-music-server/src/main/java/com/yanghi/haimusic/handler/GlobalExceptionHandler.java
+++ b/hai-music-server/src/main/java/com/yanghi/haimusic/handler/GlobalExceptionHandler.java
@@ -16,13 +16,10 @@ import java.util.List;
 public class GlobalExceptionHandler {
 
     /**
-     * 当控制器方法的参数校验失败时，会抛出 MethodArgumentNotValidException 异常，
-     * 此时可以通过定义全局异常处理器中的 handleMethodArgumentNotValidException 方法来处理该异常。
-     * @param e
-     * @return
+     * 处理参数校验失败时抛出的 MethodArgumentNotValidException 异常
      */
     @ExceptionHandler(MethodArgumentNotValidException.class)
-    public Result handleMethodArgumentNotValidException(MethodArgumentNotValidException e) {
+    public Result handleValidationException(MethodArgumentNotValidException e) {
         List<ObjectError> allErrors = e.getBindingResult().getAllErrors();
         StringBuilder errorMsg = new StringBuilder();
         for (ObjectError error : allErrors) {
@@ -31,8 +28,9 @@ public class GlobalExceptionHandler {
         return Result.failed(101, errorMsg.toString());
     }
 
-    //  处理绑定异常
-
+    /**
+     * 处理参数绑定失败时抛出的 BindException 异常
+     */
     @ExceptionHandler(BindException.class)
     public Result handleBindException(BindException e) {
         List<ObjectError> allErrors = e.getBindingResult().getAllErrors();
@@ -43,14 +41,12 @@ public class GlobalExceptionHandler {
         return Result.failed(101, errorMsg.toString());
     }
 
-
     /**
      * 处理其他异常
-     * @param e
-     * @return
      */
     @ExceptionHandler(Exception.class)
     public Result handleException(Exception e) {
         return Result.failed(e.getMessage());
     }
+
 }

--- a/hai-music-server/src/main/java/com/yanghi/haimusic/validators/AllowedValuesConstraint.java
+++ b/hai-music-server/src/main/java/com/yanghi/haimusic/validators/AllowedValuesConstraint.java
@@ -4,19 +4,17 @@ import com.yanghi.haimusic.validators.validators.AllowedValuesValidator;
 
 import javax.validation.Constraint;
 import javax.validation.Payload;
-import java.lang.annotation.ElementType;
-import java.lang.annotation.Retention;
-import java.lang.annotation.RetentionPolicy;
-import java.lang.annotation.Target;
+import java.lang.annotation.*;
 
-@Target(ElementType.FIELD)
+@Target({ElementType.FIELD, ElementType.PARAMETER})
 @Retention(RetentionPolicy.RUNTIME)
 @Constraint(validatedBy = AllowedValuesValidator.class)
 public @interface AllowedValuesConstraint {
 
-    String message() default "值必须为[1, 2, 3]其中一个";
+    String message() default "值必须为[1, 2, 3]其中一个，且不为 null";
 
     Class<?>[] groups() default {};
 
     Class<? extends Payload>[] payload() default {};
+
 }

--- a/hai-music-server/src/main/java/com/yanghi/haimusic/validators/validators/AllowedValuesValidator.java
+++ b/hai-music-server/src/main/java/com/yanghi/haimusic/validators/validators/AllowedValuesValidator.java
@@ -6,6 +6,9 @@ import com.yanghi.haimusic.validators.constant.CommentTypeEnum;
 import javax.validation.ConstraintValidator;
 import javax.validation.ConstraintValidatorContext;
 
+/**
+ * @author 泗安
+ */
 public class AllowedValuesValidator implements ConstraintValidator<AllowedValuesConstraint, Integer> {
 
     @Override
@@ -16,7 +19,7 @@ public class AllowedValuesValidator implements ConstraintValidator<AllowedValues
     @Override
     public boolean isValid(Integer value, ConstraintValidatorContext context) {
         if (value == null) {
-            return true;
+            return false;
         }
         for (CommentTypeEnum allowedValue : CommentTypeEnum.values()) {
             if (allowedValue.getValue() == value) {


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/82752725/229839947-6d8d57d3-a4c0-4c8c-aa3c-39637dfedeeb.png)
在AllowedValuesValidator参数校验器中，改变 `isVaild` 方法：
* 当 `value == null` 返回 `true`，改为返回 `false`。

现在该参数校验器具有参数必须为一系列值中的一个，而且该参数不为null。